### PR TITLE
feat: add usb custom bulk trans - Add USB bulk transfer example project for ESP32-S3 device

### DIFF
--- a/build_config.yml
+++ b/build_config.yml
@@ -103,6 +103,10 @@ projects:
     idf_version: release-v5.4
     target: esp32s3
 
+  - path: examples/usb/device/bulk_trans
+    idf_version: release-v5.4
+    target: esp32s3
+
   - path: examples/usb/device/hid_device_audio_ctrl
     idf_version: release-v5.4
     target: esp32s3

--- a/examples/usb/device/bulk_trans/CMakeLists.txt
+++ b/examples/usb/device/bulk_trans/CMakeLists.txt
@@ -1,0 +1,6 @@
+# The following five lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.16)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(bulk_trans)

--- a/examples/usb/device/bulk_trans/README.md
+++ b/examples/usb/device/bulk_trans/README.md
@@ -1,0 +1,3 @@
+# USB Bulk Trans
+
+This example demonstrates how to implement bulk transfer using the USB interface of the ESP32-S3. The example only shows the read and echo functionality.

--- a/examples/usb/device/bulk_trans/main/CMakeLists.txt
+++ b/examples/usb/device/bulk_trans/main/CMakeLists.txt
@@ -1,0 +1,17 @@
+idf_component_register(SRC_DIRS "."
+                    INCLUDE_DIRS "." "tusb")
+
+# Determine whether tinyusb is fetched from component registry or from local path
+idf_build_get_property(build_components BUILD_COMPONENTS)
+if(tinyusb IN_LIST build_components)
+    set(tinyusb_name tinyusb) # Local component
+else()
+    set(tinyusb_name espressif__tinyusb) # Managed component
+endif()
+
+idf_component_get_property(tusb_lib ${tinyusb_name} COMPONENT_LIB)
+target_include_directories(${tusb_lib} PUBLIC "${PROJECT_DIR}/main/tusb")
+target_sources(${tusb_lib} PUBLIC "${PROJECT_DIR}/main/tusb/usb_descriptors.c")
+
+cmake_policy(SET CMP0079 NEW)
+target_link_libraries(${tusb_lib} PRIVATE ${COMPONENT_LIB})

--- a/examples/usb/device/bulk_trans/main/bulk_trans.c
+++ b/examples/usb/device/bulk_trans/main/bulk_trans.c
@@ -1,0 +1,71 @@
+#include "freertos/FreeRTOS.h"
+#include "freertos/task.h"
+#include "esp_log.h"
+#include "tusb.h"
+#include "device/usbd.h"
+#include "esp_private/usb_phy.h"
+#include "usb_descriptors.h"
+
+static const char *TAG = "usb_bulk";
+#define CONFIG_USB_VENDOR_RX_BUFSIZE  VENDOR_BUF_SIZE
+
+static uint8_t rx_buffer[CONFIG_USB_VENDOR_RX_BUFSIZE];
+
+static void usb_phy_init(void)
+{
+    usb_phy_handle_t phy_hdl;
+    // Configure USB PHY
+    usb_phy_config_t phy_conf = {
+        .controller = USB_PHY_CTRL_OTG,
+        .otg_mode = USB_OTG_MODE_DEVICE,
+    };
+    phy_conf.target = USB_PHY_TARGET_INT;
+    usb_new_phy(&phy_conf, &phy_hdl);
+}
+
+static void tusb_device_task(void *arg)
+{
+    while (1) {
+        tud_task();
+    }
+}
+
+void tud_vendor_rx_cb(uint8_t itf, uint8_t const *buffer, uint16_t bufsize)
+{
+    while (tud_vendor_n_available(itf)) {
+        int read_res = tud_vendor_n_read(itf, rx_buffer, CONFIG_USB_VENDOR_RX_BUFSIZE);
+        if (read_res > 0) {
+            ESP_LOGI(TAG, "RX %d bytes: %.*s", read_res, read_res, rx_buffer);
+
+            // Echo back the received data
+            if (tud_vendor_n_write(itf, rx_buffer, read_res)) {
+                tud_vendor_n_flush(itf);
+                ESP_LOGI(TAG, "Echo back %d bytes", read_res);
+            }
+        }
+    }
+}
+
+void tud_mount_cb(void)
+{
+    ESP_LOGI(TAG, "USB device mounted");
+}
+
+void tud_umount_cb(void)
+{
+    ESP_LOGI(TAG, "USB device unmounted");
+}
+
+void app_main(void)
+{
+    esp_err_t ret = ESP_OK;
+
+    usb_phy_init();
+    bool usb_init = tusb_init();
+    if (!usb_init) {
+        ESP_LOGE(TAG, "USB Device Stack Init Fail");
+        return;
+    }
+
+    xTaskCreate(tusb_device_task, "tusb_device_task", 4096, NULL, 5, NULL);
+}

--- a/examples/usb/device/bulk_trans/main/idf_component.yml
+++ b/examples/usb/device/bulk_trans/main/idf_component.yml
@@ -1,0 +1,17 @@
+## IDF Component Manager Manifest File
+dependencies:
+  ## Required IDF version
+  idf:
+    version: '>=4.1.0'
+  # # Put list of dependencies here
+  # # For components maintained by Espressif:
+  # component: "~1.0.0"
+  # # For 3rd party components:
+  # username/component: ">=1.0.0,<2.0.0"
+  # username2/component2:
+  #   version: "~1.0.0"
+  #   # For transient dependencies `public` flag can be set.
+  #   # `public` flag doesn't have an effect dependencies of the `main` component.
+  #   # All dependencies of `main` are public by default.
+  #   public: true
+  espressif/tinyusb: ==0.18.0~2

--- a/examples/usb/device/bulk_trans/main/tusb/tusb_config.h
+++ b/examples/usb/device/bulk_trans/main/tusb/tusb_config.h
@@ -1,0 +1,119 @@
+/*
+ * The MIT License (MIT)
+ *
+ * Copyright (c) 2019 Ha Thach (tinyusb.org)
+ *
+ * Permission is hereby granted, free of charge, to any person obtaining a copy
+ * of this software and associated documentation files (the "Software"), to deal
+ * in the Software without restriction, including without limitation the rights
+ * to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+ * copies of the Software, and to permit persons to whom the Software is
+ * furnished to do so, subject to the following conditions:
+ *
+ * The above copyright notice and this permission notice shall be included in
+ * all copies or substantial portions of the Software.
+ *
+ * THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+ * IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+ * FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+ * AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+ * LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+ * OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN
+ * THE SOFTWARE.
+ *
+ */
+
+#pragma once
+
+#include "sdkconfig.h"
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+//--------------------------------------------------------------------+
+// Board Specific Configuration
+//--------------------------------------------------------------------+
+
+#ifdef CONFIG_TINYUSB_RHPORT_HS
+#   define CFG_TUSB_RHPORT1_MODE    OPT_MODE_DEVICE | OPT_MODE_HIGH_SPEED
+#   define CONFIG_USB_HS            1
+#else
+#   define CFG_TUSB_RHPORT0_MODE    OPT_MODE_DEVICE | OPT_MODE_FULL_SPEED
+#   define CONFIG_USB_HS            0
+#endif
+
+//--------------------------------------------------------------------
+// Common Configuration
+//--------------------------------------------------------------------
+
+// defined by compiler flags for flexibility
+#ifndef CFG_TUSB_MCU
+#error CFG_TUSB_MCU must be defined
+#endif
+
+#ifndef CFG_TUSB_OS
+#define CFG_TUSB_OS           OPT_OS_FREERTOS
+#endif
+
+#ifndef ESP_PLATFORM
+#define ESP_PLATFORM 1
+#endif
+
+// Espressif IDF requires "freertos/" prefix in include path
+#if TU_CHECK_MCU(OPT_MCU_ESP32S2, OPT_MCU_ESP32S3, OPT_MCU_ESP32P4)
+#define CFG_TUSB_OS_INC_PATH    freertos/
+#endif
+
+#ifndef CFG_TUSB_DEBUG
+#define CFG_TUSB_DEBUG        1
+#endif
+
+// #ifndef USB_OTG_HS_PERIPH_BASE
+// #define USB_OTG_HS_PERIPH_BASE 1
+// #endif
+
+// Enable Device stack
+#define CFG_TUD_ENABLED       1
+
+/* USB DMA on some MCUs can only access a specific SRAM region with restriction on alignment.
+ * Tinyusb use follows macros to declare transferring memory so that they can be put
+ * into those specific section.
+ * e.g
+ * - CFG_TUSB_MEM SECTION : __attribute__ (( section(".usb_ram") ))
+ * - CFG_TUSB_MEM_ALIGN   : __attribute__ ((aligned(4)))
+ */
+#ifndef CFG_TUSB_MEM_SECTION
+#define CFG_TUSB_MEM_SECTION
+#endif
+
+#ifndef CFG_TUSB_MEM_ALIGN
+#define CFG_TUSB_MEM_ALIGN        __attribute__ ((aligned(4)))
+#endif
+
+//--------------------------------------------------------------------
+// DEVICE CONFIGURATION
+//--------------------------------------------------------------------
+
+#ifndef CFG_TUD_ENDPOINT0_SIZE
+#define CFG_TUD_ENDPOINT0_SIZE    64
+#endif
+
+#define USB_VID                      0xcafe
+#define USB_PID                      0x4001
+#define USB_MANUFACTURER             "Espressif"
+#define USB_PRODUCT                  "Vendor"
+
+//------------- CLASS -------------//
+/*!< Vendor Class */
+#define CFG_TUD_VENDOR               1
+#define VENDOR_BUF_SIZE              (CONFIG_USB_HS ? 512 : 64)
+#define CFG_TUD_VENDOR_RX_BUFSIZE    (VENDOR_BUF_SIZE * 10)
+#define CFG_TUD_VENDOR_TX_BUFSIZE    VENDOR_BUF_SIZE
+#ifndef CFG_TUD_VENDOR_EPSIZE
+#define CFG_TUD_VENDOR_EPSIZE        VENDOR_BUF_SIZE
+#endif
+
+#ifdef __cplusplus
+}
+#endif

--- a/examples/usb/device/bulk_trans/main/tusb/usb_descriptors.c
+++ b/examples/usb/device/bulk_trans/main/tusb/usb_descriptors.c
@@ -1,0 +1,107 @@
+#include <stdio.h>
+#include <stdlib.h>
+#include <string.h>
+#include "tusb.h"
+#include "tusb_config.h"
+#include "usb_descriptors.h"
+#include "sdkconfig.h"
+
+
+//--------------------------------------------------------------------+
+// Device Descriptors
+//--------------------------------------------------------------------+
+tusb_desc_device_t const desc_device = {
+    .bLength            = sizeof(tusb_desc_device_t),
+    .bDescriptorType    = TUSB_DESC_DEVICE,
+    .bcdUSB             = 0x0200,
+
+    // Use Interface Association Descriptor (IAD) for Video
+    // As required by USB Specs IAD's subclass must be common class (2) and protocol must be IAD (1)
+    .bDeviceClass       = TUSB_CLASS_UNSPECIFIED,
+    .bDeviceSubClass    = TUSB_CLASS_UNSPECIFIED,
+    .bDeviceProtocol    = TUSB_CLASS_UNSPECIFIED,
+
+    .bMaxPacketSize0    = CFG_TUD_ENDPOINT0_SIZE,
+
+    .idVendor           = USB_VID,
+    .idProduct          = USB_PID,
+    .bcdDevice          = 0x0101,
+
+    .iManufacturer      = 0x01,
+    .iProduct           = 0x02,
+    .iSerialNumber      = 0x03,
+
+    .bNumConfigurations = 0x01
+};
+
+uint8_t const *tud_descriptor_device_cb(void)
+{
+    return (uint8_t const *) &desc_device;
+}
+
+//--------------------------------------------------------------------+
+// Configuration Descriptor
+//--------------------------------------------------------------------+
+#define CONFIG_TOTAL_LEN    (TUD_CONFIG_DESC_LEN + TUD_VENDOR_DESC_LEN * CFG_TUD_VENDOR)
+uint8_t const desc_fs_configuration[] = {
+    // Config number, interface count, string index, total length, attribute, power in mA
+    TUD_CONFIG_DESCRIPTOR(1, ITF_NUM_TOTAL, 0, CONFIG_TOTAL_LEN, 0, 100),
+    // Interface number, string index, EP Out & IN address, EP size
+    TUD_VENDOR_DESCRIPTOR(ITF_NUM_VENDOR, 4, EPNUM_VENDOR, 0x80 | EPNUM_VENDOR, CFG_TUD_VENDOR_EPSIZE),
+};
+
+uint8_t const *tud_descriptor_configuration_cb(uint8_t index)
+{
+    (void) index; // for multiple configurations
+    return desc_fs_configuration;
+}
+
+//--------------------------------------------------------------------+
+// String Descriptors
+//--------------------------------------------------------------------+
+
+char const *string_desc_arr [] = {
+    (const char[]) { 0x09, 0x04 },    // 0: is supported language is English (0x0409)
+    USB_MANUFACTURER,                 // 1: Manufacturer
+    "ESP_Bulk_Trans",              // 2: Product
+    "012-2021",                       // 3: Serials, should use chip ID
+};
+
+static uint16_t _desc_str[64];
+
+uint16_t const *tud_descriptor_string_cb(uint8_t index, uint16_t langid)
+{
+    (void) langid;
+
+    uint8_t chr_count;
+
+    if (index == 0) {
+        memcpy(&_desc_str[1], string_desc_arr[0], 2);
+        chr_count = 1;
+    } else {
+        // Note: the 0xEE index string is a Microsoft OS 1.0 Descriptors.
+        // https://docs.microsoft.com/en-us/windows-hardware/drivers/usbcon/microsoft-defined-usb-descriptors
+
+        if (!(index < sizeof(string_desc_arr) / sizeof(string_desc_arr[0]))) {
+            return NULL;
+        }
+
+        const char *str = (char *)string_desc_arr[index];
+
+        // Cap at max char
+        chr_count = (uint8_t) strlen(str);
+        if (chr_count > 63) {
+            chr_count = 63;
+        }
+
+        // Convert ASCII string into UTF-16
+        for (uint8_t i = 0; i < chr_count; i++) {
+            _desc_str[1 + i] = str[i];
+        }
+    }
+
+    // first byte is length (including header), second byte is string type
+    _desc_str[0] = (uint16_t)((TUSB_DESC_STRING << 8) | (2 * chr_count + 2));
+
+    return _desc_str;
+}

--- a/examples/usb/device/bulk_trans/main/tusb/usb_descriptors.h
+++ b/examples/usb/device/bulk_trans/main/tusb/usb_descriptors.h
@@ -1,0 +1,14 @@
+#pragma once
+
+#include "tusb.h"
+
+enum {
+    ITF_NUM_VENDOR = 0,
+    ITF_NUM_TOTAL,
+};
+
+enum {
+    EPNUM_DEFAULT = 0,
+    EPNUM_VENDOR,
+    EPNUM_TOTAL
+};

--- a/examples/usb/device/bulk_trans/sdkconfig.defaults
+++ b/examples/usb/device/bulk_trans/sdkconfig.defaults
@@ -1,0 +1,4 @@
+# This file was generated using idf.py save-defconfig. It can be edited manually.
+# Espressif IoT Development Framework (ESP-IDF) 6.0.0 Project Minimal Configuration
+#
+CONFIG_IDF_TARGET="esp32s3"

--- a/examples/usb/device/bulk_trans/test.py
+++ b/examples/usb/device/bulk_trans/test.py
@@ -1,0 +1,72 @@
+import usb.core
+import usb.util
+import time
+
+VID = 0xCAFE
+PID = 0x4001
+
+# Find device
+dev = usb.core.find(idVendor=VID, idProduct=PID)
+if dev is None:
+    raise ValueError('Device not found')
+
+print('Device found!')
+
+# Check if device is already opened
+try:
+    # Try to get current configuration
+    current_cfg = dev.get_active_configuration()
+    print('Device is already configured')
+except usb.core.USBError:
+    # If getting configuration fails, device is not opened, need to set configuration
+    print('Device is not configured, setting configuration...')
+    dev.set_configuration()
+    current_cfg = dev.get_active_configuration()
+
+# Get interface
+intf = current_cfg[(0, 0)]
+
+# Find endpoints
+ep_out = usb.util.find_descriptor(
+    intf,
+    custom_match=lambda e: usb.util.endpoint_direction(e.bEndpointAddress) == usb.util.ENDPOINT_OUT
+)
+ep_in = usb.util.find_descriptor(
+    intf,
+    custom_match=lambda e: usb.util.endpoint_direction(e.bEndpointAddress) == usb.util.ENDPOINT_IN
+)
+
+assert ep_out is not None, 'OUT endpoint not found'
+assert ep_in is not None, 'IN endpoint not found'
+
+# Send and receive data
+try:
+    # Send fixed data
+    message = b'Hello ESP32!'
+    print('Sending:', message)
+    ep_out.write(message)
+
+    # Receive data
+    try:
+        data = ep_in.read(64, timeout=1000)  # Read up to 64 bytes, timeout 1 second
+        print('Received:', data.tobytes().decode('utf-8'))
+    except usb.core.USBTimeoutError:
+        print('No response received (timeout)')
+    except Exception as e:
+        print('Error receiving data:', str(e))
+
+    # Close device
+    print('Closing device...')
+    usb.util.release_interface(dev, intf)
+    usb.util.dispose_resources(dev)
+    print('Device closed successfully')
+
+except Exception as e:
+    print('Error:', str(e))
+    # Ensure device is closed on error
+    try:
+        usb.util.release_interface(dev, intf)
+        usb.util.dispose_resources(dev)
+        print('Device closed successfully')
+    except:
+        pass

--- a/tools/ci/check_copyright_config.yaml
+++ b/tools/ci/check_copyright_config.yaml
@@ -41,3 +41,4 @@ ignore:  # You can also select ignoring files here
  perform_check: no  # Don't check files from that block
  include:
    - 'esp_video/include/linux/**/*'
+   - '../../examples/usb/device/bulk_trans/main/tusb/**/*'


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Introduced a USB bulk transfer example for ESP32-S3 demonstrating data read and echo over USB using TinyUSB.
  - Added configuration files, USB descriptors, and component manifests for device setup.
  - Included a test script to verify USB communication with the device.

- **Documentation**
  - Added a README providing an overview of the USB bulk transfer example.

- **Chores**
  - Updated configuration to exclude new example files from copyright checks.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->