### PR TITLE
feat: add kconfig for http example Add Kconfig file and update source to use configurable credentials

### DIFF
--- a/build_config.yml
+++ b/build_config.yml
@@ -35,6 +35,38 @@ projects:
     idf_version: release-v5.4
     target: esp32s3
 
+  - path: examples/http/esp_gpt
+    idf_version: release-v5.4
+    target: esp32s3
+
+  - path: examples/http/http_aliyun_tongyiqianwen
+    idf_version: release-v5.4
+    target: esp32s3
+
+  - path: examples/http/http_baidu_access_token
+    idf_version: release-v5.4
+    target: esp32s3
+
+  - path: examples/http/http_baidu_img_classification
+    idf_version: release-v5.4
+    target: esp32s3
+
+  - path: examples/http/http_baidu_speech_recognition
+    idf_version: release-v5.4
+    target: esp32s3
+
+  - path: examples/http/http_baidu_tts
+    idf_version: release-v5.4
+    target: esp32s3
+
+  - path: examples/http/http_kimi
+    idf_version: release-v5.4
+    target: esp32s3
+
+  - path: examples/http/http_xunfei_xinghuo
+    idf_version: release-v5.4
+    target: esp32s3
+
   - path: examples/peripherals/can/can_alert
     idf_version: release-v5.4
     target: esp32s3

--- a/examples/http/esp_gpt/main/Kconfig.projbuild
+++ b/examples/http/esp_gpt/main/Kconfig.projbuild
@@ -1,0 +1,27 @@
+menu "Example Configuration"
+
+    config EXAMPLE_ACCESS_TOKEN
+        string "Baidu Access Token"
+        default "baidu_access_token"
+        help
+                Access token for baidu.
+
+    config EXAMPLE_TONGYI_KEY
+        string "Tongyi Key"
+        default "tongyi_key"
+        help
+                API Key for tongyi.
+
+    config EXAMPLE_WIFI_SSID
+        string "wifi ssid"
+        default "my_wifi_ssid"
+        help
+                Wifi SSID.
+
+    config EXAMPLE_WIFI_PSWD
+        string "wifi pswd"
+        default "my_wifi_pswd"
+        help
+                Wifi PASSWORD.
+
+endmenu

--- a/examples/http/esp_gpt/main/app_http/app_http_asr.c
+++ b/examples/http/esp_gpt/main/app_http/app_http_asr.c
@@ -6,7 +6,7 @@
 #include "app_http_tongyi.h"
 
 static const char *TAG = "BAIDU ASR";
-char *access_token = "25.5d2271f2f6537871c8576a94aea77de0.315360000.2028702861.282335-60592936";
+char *access_token = CONFIG_EXAMPLE_ACCESS_TOKEN;
 char *url_formate = "http://vop.baidu.com/server_api?dev_pid=1537&cuid=dPKArKm9yCGIOwPoCSjTDzmIIj4cBsEV&token=%s";
 esp_http_client_handle_t asr_client;
 char asr_result[1024] = {};

--- a/examples/http/esp_gpt/main/app_http/app_http_tongyi.c
+++ b/examples/http/esp_gpt/main/app_http/app_http_tongyi.c
@@ -10,7 +10,7 @@ esp_http_client_handle_t tongyi_client;
 QueueHandle_t xTongyiQuestion;
 static const char *TAG = "TONGYI";
 char *tongyi_url = "https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation";
-char *key = "";
+char *key = CONFIG_EXAMPLE_TONGYI_KEY;
 char *format = "{\"model\": \"qwen-turbo\",\"input\": {\"messages\": [{\"role\": \"system\",\"content\": \"You are a helpful assistant.\"},{\"role\": \"user\",\"content\": \"%s\"}]},\"parameters\": {\"result_format\": \"message\"}}";
 char tongyi_result[1024];
 

--- a/examples/http/esp_gpt/main/app_http/app_http_tts.c
+++ b/examples/http/esp_gpt/main/app_http/app_http_tts.c
@@ -6,7 +6,7 @@
 static const char *TAG = "BAIDU TTS";
 esp_http_client_handle_t tts_client;
 static char *url = "https://tsn.baidu.com/text2audio";
-static char *access_token = "24.23d20894d86ee25c834f2f15c757d225.2592000.1715916123.282335-60592936";
+static char *access_token = CONFIG_EXAMPLE_ACCESS_TOKEN;
 static char *formate = "tex=%s&tok=%s&cuid=mpBNOBqqTHmz93GbNEZDm5vUnwV0Lnm1&ctp=1&lan=zh&spd=5&pit=5&vol=0&per=4&aue=4"; // PCM 16K
 
 esp_err_t app_http_baidu_tts_event_handler(esp_http_client_event_t *evt)

--- a/examples/http/esp_gpt/main/main.c
+++ b/examples/http/esp_gpt/main/main.c
@@ -58,7 +58,7 @@ void app_main(void)
     ESP_ERROR_CHECK(hal_i2s_microphone_init(i2s_microphone_config));
 
     // Init wifi
-    app_wifi_init("ChinaUnicom-3LRNAS", "244244244");
+    app_wifi_init(CONFIG_EXAMPLE_WIFI_SSID, CONFIG_EXAMPLE_WIFI_PSWD);
 
     // Init button
     button_config_t btn_cfg = {

--- a/examples/http/http_aliyun_tongyiqianwen/main/Kconfig.projbuild
+++ b/examples/http/http_aliyun_tongyiqianwen/main/Kconfig.projbuild
@@ -1,0 +1,21 @@
+menu "Example Configuration"
+
+    config EXAMPLE_TONGYI_KEY
+        string "Tongyi Key"
+        default "tongyi_key"
+        help
+                API Key for tongyi.
+
+    config EXAMPLE_WIFI_SSID
+        string "wifi ssid"
+        default "my_wifi_ssid"
+        help
+                Wifi SSID.
+
+    config EXAMPLE_WIFI_PSWD
+        string "wifi pswd"
+        default "my_wifi_pswd"
+        help
+                Wifi PASSWORD.
+
+endmenu

--- a/examples/http/http_aliyun_tongyiqianwen/main/main.c
+++ b/examples/http/http_aliyun_tongyiqianwen/main/main.c
@@ -13,7 +13,7 @@ static const char *TAG = "HTTP_TONGYI";
 esp_http_client_handle_t client;
 QueueHandle_t xQueue;
 char *tongyi_url = "https://dashscope.aliyuncs.com/api/v1/services/aigc/text-generation/generation";
-char *key = "";
+char *key = CONFIG_EXAMPLE_TONGYI_KEY;
 char *format = "{\"model\": \"qwen-turbo\",\"input\": {\"messages\": [{\"role\": \"system\",\"content\": \"You are a helpful assistant.\"},{\"role\": \"user\",\"content\": \"%s\"}]},\"parameters\": {\"result_format\": \"message\"}}";
 
 esp_err_t app_http_tongyi_event_handler(esp_http_client_event_t *evt)
@@ -77,7 +77,7 @@ void app_main(void)
     ESP_ERROR_CHECK(ret);
 
     // Connect WIFI
-    app_wifi_init("MERCURY_5B00", "tzyjy12345678");
+    app_wifi_init(CONFIG_EXAMPLE_WIFI_SSID, CONFIG_EXAMPLE_WIFI_PSWD);
 
     // Init queue
     xQueue = xQueueCreate(10, 1024);

--- a/examples/http/http_baidu_access_token/main/Kconfig.projbuild
+++ b/examples/http/http_baidu_access_token/main/Kconfig.projbuild
@@ -1,0 +1,27 @@
+menu "Example Configuration"
+
+    config EXAMPLE_CLIENT_ID
+        string "Baidu Client Id"
+        default "baidu_client_id"
+        help
+                Client id for baidu.
+
+    config EXAMPLE_CLIENT_SECRET
+        string "Baidu Client Secret"
+        default "baidu_access_token"
+        help
+                Client Secret for baidu.
+
+    config EXAMPLE_WIFI_SSID
+        string "wifi ssid"
+        default "my_wifi_ssid"
+        help
+                Wifi SSID.
+
+    config EXAMPLE_WIFI_PSWD
+        string "wifi pswd"
+        default "my_wifi_pswd"
+        help
+                Wifi PASSWORD.
+
+endmenu

--- a/examples/http/http_baidu_access_token/main/main.c
+++ b/examples/http/http_baidu_access_token/main/main.c
@@ -10,8 +10,8 @@
 #include <json_parser.h>
 
 static const char *TAG = "BAIDU_ACCESS_TOKEN";
-char *client_id = "VHmYbhR424X5zfTRooHYD7ve";
-char *client_secret = "ODH92wNoceW8kXtgxoxCyHidhWfeX8YV";
+char *client_id = CONFIG_EXAMPLE_CLIENT_ID;
+char *client_secret = CONFIG_EXAMPLE_CLIENT_SECRET;
 char *url_format = "https://aip.baidubce.com/oauth/2.0/token?client_id=%s&client_secret=%s&grant_type=client_credentials";
 char access_token[256] = {0};
 esp_http_client_handle_t client;
@@ -48,7 +48,7 @@ void app_main(void)
     ESP_ERROR_CHECK(ret);
 
     // Connect WIFI
-    app_wifi_init("MERCURY_5B00", "tzyjy12345678");
+    app_wifi_init(CONFIG_EXAMPLE_WIFI_SSID, CONFIG_EXAMPLE_WIFI_PSWD);
 
     // Http
     esp_http_client_config_t config = {

--- a/examples/http/http_baidu_img_classification/main/Kconfig.projbuild
+++ b/examples/http/http_baidu_img_classification/main/Kconfig.projbuild
@@ -1,0 +1,21 @@
+menu "Example Configuration"
+
+    config EXAMPLE_ACCESS_TOKEN
+        string "Baidu Access Token"
+        default "baidu_access_token"
+        help
+                Access token for baidu.
+
+    config EXAMPLE_WIFI_SSID
+        string "wifi ssid"
+        default "my_wifi_ssid"
+        help
+                Wifi SSID.
+
+    config EXAMPLE_WIFI_PSWD
+        string "wifi pswd"
+        default "my_wifi_pswd"
+        help
+                Wifi PASSWORD.
+
+endmenu

--- a/examples/http/http_baidu_img_classification/main/app_baidu/app_baidu.c
+++ b/examples/http/http_baidu_img_classification/main/app_baidu/app_baidu.c
@@ -7,7 +7,7 @@
 
 static const char *TAG = "HTTP_BAIDU";
 
-char access_token[256] = "24.fe3e85829eb140d1ed7725eacf1eb8ad.2592000.1715228423.282335-56823135";
+char access_token[256] = CONFIG_EXAMPLE_ACCESS_TOKEN;
 char base_url[256] = "https://aip.baidubce.com/rest/2.0/image-classify/v2/advanced_general";
 
 esp_err_t app_http_baidu_event_handler(esp_http_client_event_t *evt)

--- a/examples/http/http_baidu_img_classification/main/main.c
+++ b/examples/http/http_baidu_img_classification/main/main.c
@@ -25,7 +25,7 @@ void app_main(void)
     ESP_ERROR_CHECK(ret);
 
     // Connect WIFI
-    app_wifi_init("MERCURY_5B00", "tzyjy12345678");
+    app_wifi_init(CONFIG_EXAMPLE_WIFI_SSID, CONFIG_EXAMPLE_WIFI_PSWD);
 
     // Mount spiffs
     ESP_ERROR_CHECK(hal_spiffs_init("/spiffs"));
@@ -42,14 +42,14 @@ void app_main(void)
     rewind(f);
     ESP_LOGI(TAG, "File size:%zu", filesize);
 
-    file_buf = (char *)malloc(filesize + 1); // 加1是为了存放字符串结束符
+    file_buf = (char *)malloc(filesize + 1);
     if (file_buf == NULL) {
         fprintf(stderr, "Memory allocation failed.\n");
         fclose(f);
         return;
     }
 
-    // 读取文件内容
+    // Read the file
     if (fread(file_buf, 1, filesize, f) != filesize) {
         fprintf(stderr, "Failed to read the file.\n");
         fclose(f);
@@ -57,7 +57,7 @@ void app_main(void)
         return;
     }
 
-    // 关闭文件
+    // Close the file
     fclose(f);
 
     app_baidu_classification(file_buf, filesize);

--- a/examples/http/http_baidu_speech_recognition/main/Kconfig.projbuild
+++ b/examples/http/http_baidu_speech_recognition/main/Kconfig.projbuild
@@ -1,0 +1,21 @@
+menu "Example Configuration"
+
+    config EXAMPLE_ACCESS_TOKEN
+        string "Baidu Access Token"
+        default "baidu_access_token"
+        help
+                Access token for baidu.
+
+    config EXAMPLE_WIFI_SSID
+        string "wifi ssid"
+        default "my_wifi_ssid"
+        help
+                Wifi SSID.
+
+    config EXAMPLE_WIFI_PSWD
+        string "wifi pswd"
+        default "my_wifi_pswd"
+        help
+                Wifi PASSWORD.
+
+endmenu

--- a/examples/http/http_baidu_speech_recognition/main/main.c
+++ b/examples/http/http_baidu_speech_recognition/main/main.c
@@ -21,7 +21,7 @@ i2s_microphone_config_t i2s_microphone_config = {
     .bits_per_sample = I2S_DATA_BIT_WIDTH_16BIT,
 };
 
-char *access_token = "24.4c1cacd26dc1b0f768a3b48ca393bd8c.2592000.1715692765.282335-60592936";
+char *access_token = CONFIG_EXAMPLE_ACCESS_TOKEN;
 char *url_formate = "http://vop.baidu.com/server_api?dev_pid=1537&cuid=dPKArKm9yCGIOwPoCSjTDzmIIj4cBsEV&token=%s";
 esp_http_client_handle_t client;
 
@@ -49,7 +49,7 @@ void app_main(void)
     ESP_ERROR_CHECK(ret);
 
     // Connect WIFI
-    app_wifi_init("MERCURY_5B00", "tzyjy12345678");
+    app_wifi_init(CONFIG_EXAMPLE_WIFI_SSID, CONFIG_EXAMPLE_WIFI_PSWD);
 
     // Init spiffs
     ESP_ERROR_CHECK(app_spiffs_init("/spiffs"));

--- a/examples/http/http_baidu_tts/main/Kconfig.projbuild
+++ b/examples/http/http_baidu_tts/main/Kconfig.projbuild
@@ -1,0 +1,21 @@
+menu "Example Configuration"
+
+    config EXAMPLE_ACCESS_TOKEN
+        string "Baidu Access Token"
+        default "baidu_access_token"
+        help
+                Access token for baidu.
+
+    config EXAMPLE_WIFI_SSID
+        string "wifi ssid"
+        default "my_wifi_ssid"
+        help
+                Wifi SSID.
+
+    config EXAMPLE_WIFI_PSWD
+        string "wifi pswd"
+        default "my_wifi_pswd"
+        help
+                Wifi PASSWORD.
+
+endmenu

--- a/examples/http/http_baidu_tts/main/main.c
+++ b/examples/http/http_baidu_tts/main/main.c
@@ -14,9 +14,9 @@
 static const char *TAG = "HTTP_BAIDU";
 esp_http_client_handle_t client;
 char *url = "https://tsn.baidu.com/text2audio";
-char *access_token = "24.3ff7eb10fd7de8342cf12fde2fd35194.2592000.1715402191.282335-60592936";
+char *access_token = CONFIG_EXAMPLE_ACCESS_TOKEN;
 char *formate = "tex=%s&tok=%s&cuid=mpBNOBqqTHmz93GbNEZDm5vUnwV0Lnm1&ctp=1&lan=zh&spd=5&pit=5&vol=5&per=4&aue=4"; // PCM 16K
-char *text = "早上好,下午好,晚上好";
+char *text = "Good morning";
 size_t text_url_encode_size = 0;
 
 i2s_chan_handle_t i2s_tx_chan;
@@ -44,8 +44,7 @@ void app_main(void)
     ESP_ERROR_CHECK(ret);
 
     // Connect WIFI
-    // app_wifi_init("ChinaUnicom-3LRNAS", "244244244");
-    app_wifi_init("MERCURY_5B00", "tzyjy12345678");
+    app_wifi_init(CONFIG_EXAMPLE_WIFI_SSID, CONFIG_EXAMPLE_WIFI_PSWD);
 
     // Init audio
     audio_i2s_init(I2S_NUM_0, GPIO_NUM_3, &i2s_tx_chan, 16 * 1000);

--- a/examples/http/http_kimi/main/Kconfig.projbuild
+++ b/examples/http/http_kimi/main/Kconfig.projbuild
@@ -1,0 +1,21 @@
+menu "Example Configuration"
+
+    config EXAMPLE_KIMI_KEY
+        string "Kimi Api Key"
+        default "kimi_api_key"
+        help
+                API key for kimi model.
+
+    config EXAMPLE_WIFI_SSID
+        string "wifi ssid"
+        default "my_wifi_ssid"
+        help
+                Wifi SSID.
+
+    config EXAMPLE_WIFI_PSWD
+        string "wifi pswd"
+        default "my_wifi_pswd"
+        help
+                Wifi PASSWORD.
+
+endmenu

--- a/examples/http/http_kimi/main/main.c
+++ b/examples/http/http_kimi/main/main.c
@@ -8,7 +8,7 @@
 
 static const char *TAG = "KIMI";
 char *kimi_url = "https://api.moonshot.cn/v1/chat/completions";
-char *kimi_key = "";
+char *kimi_key = CONFIG_EXAMPLE_KIMI_KEY;
 char *kimi_authorization_formate = "Bearer %s";
 char *kimi_message = "{\"model\": \"moonshot-v1-8k\",\"messages\": [{\"role\": \"system\", \"content\": \"you are Kimi\"},{\"role\": \"user\", \"content\": \"hello,good morning\"}],\"temperature\": 0.3}";
 esp_http_client_handle_t client;
@@ -33,7 +33,7 @@ void app_main(void)
     ESP_ERROR_CHECK(ret);
 
     // Connect wifi
-    app_wifi_init("1401", "15201882219");
+    app_wifi_init(CONFIG_EXAMPLE_WIFI_SSID, CONFIG_EXAMPLE_WIFI_PSWD);
 
     // Set http
     esp_http_client_config_t config = {

--- a/examples/http/http_xunfei_xinghuo/main/Kconfig.projbuild
+++ b/examples/http/http_xunfei_xinghuo/main/Kconfig.projbuild
@@ -1,0 +1,27 @@
+menu "Example Configuration"
+
+    config EXAMPLE_XF_KEY
+        string "XF Api Key"
+        default "xf_api_key"
+        help
+                API key for xf model.
+
+    config EXAMPLE_XF_SECRET
+        string "XF Api Secret"
+        default "xf_api_secret"
+        help
+                API secret for xf model.
+
+    config EXAMPLE_WIFI_SSID
+        string "wifi ssid"
+        default "my_wifi_ssid"
+        help
+                Wifi SSID.
+
+    config EXAMPLE_WIFI_PSWD
+        string "wifi pswd"
+        default "my_wifi_pswd"
+        help
+                Wifi PASSWORD.
+
+endmenu

--- a/examples/http/http_xunfei_xinghuo/main/main.c
+++ b/examples/http/http_xunfei_xinghuo/main/main.c
@@ -7,8 +7,8 @@
 #include "esp_heap_caps.h"
 
 char *xf_url = "https://spark-api-open.xf-yun.com/v1/chat/completions";
-char *xf_key = "";
-char *xf_secret = "";
+char *xf_key = CONFIG_EXAMPLE_XF_KEY;
+char *xf_secret = CONFIG_EXAMPLE_XF_SECRET;
 char *xf_authorization_formate = "Bearer %s:%s";
 char *xf_message = "{\"model\": \"generalv3.5\", \"messages\": [{\"role\": \"user\", \"content\": \"你是谁\"}]}";
 
@@ -35,7 +35,7 @@ void app_main(void)
     ESP_ERROR_CHECK(ret);
 
     // Connect wifi
-    app_wifi_init("1401", "15201882219");
+    app_wifi_init(CONFIG_EXAMPLE_WIFI_SSID, CONFIG_EXAMPLE_WIFI_PSWD);
 
     // Set http
     esp_http_client_config_t config = {


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Added configuration options for API credentials and WiFi settings across multiple HTTP example projects, enabling users to customize these values during build time.

- **Refactor**
  - Updated examples to use configurable parameters for API keys, access tokens, and WiFi credentials instead of hardcoded strings, enhancing flexibility and security.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->