### PR TITLE
feat: add spi basic example

### DIFF
--- a/build_config.yml
+++ b/build_config.yml
@@ -99,6 +99,10 @@ projects:
     idf_version: release-v5.4
     target: esp32s3
 
+  - path: examples/peripherals/spi/spi_basic
+    idf_version: release-v5.4
+    target: esp32s3
+
   - path: examples/protocols/json
     idf_version: release-v5.4
     target: esp32s3

--- a/examples/peripherals/spi/spi_basic/CMakeLists.txt
+++ b/examples/peripherals/spi/spi_basic/CMakeLists.txt
@@ -1,0 +1,6 @@
+# The following five lines of boilerplate have to be in your project's
+# CMakeLists in this exact order for cmake to work correctly
+cmake_minimum_required(VERSION 3.16)
+
+include($ENV{IDF_PATH}/tools/cmake/project.cmake)
+project(spi_basic)

--- a/examples/peripherals/spi/spi_basic/main/CMakeLists.txt
+++ b/examples/peripherals/spi/spi_basic/main/CMakeLists.txt
@@ -1,0 +1,2 @@
+idf_component_register(SRCS "spi_basic.c"
+                    INCLUDE_DIRS ".")

--- a/examples/peripherals/spi/spi_basic/main/spi_basic.c
+++ b/examples/peripherals/spi/spi_basic/main/spi_basic.c
@@ -1,0 +1,35 @@
+#include <stdio.h>
+#include <string.h>
+#include "driver/gpio.h"
+#include "driver/spi_master.h"
+
+void app_main(void)
+{
+    spi_device_handle_t handle;
+
+    spi_bus_config_t buscfg = {
+        .mosi_io_num = GPIO_NUM_1,
+        .miso_io_num = GPIO_NUM_2,
+        .sclk_io_num = GPIO_NUM_3,
+        .quadwp_io_num = -1,
+        .quadhd_io_num = -1,
+    };
+    spi_bus_initialize(SPI2_HOST, &buscfg, SPI_DMA_CH_AUTO);
+
+    spi_device_interface_config_t devcfg = {
+        .clock_speed_hz = 1 * 1000 * 1000,
+        .duty_cycle_pos = 128,
+        .mode = 0,
+        .spics_io_num = GPIO_NUM_4,
+        .queue_size = 3,
+    };
+
+    spi_bus_add_device(SPI2_HOST, &devcfg, &handle);
+
+    uint8_t sendbuf[4] = {0x01, 0x00, 0x00, 0x00};
+    spi_transaction_t t;
+    memset(&t, 0, sizeof(t));
+    t.length = 4 * 8;
+    t.tx_buffer = sendbuf;
+    spi_device_transmit(handle, &t);
+}


### PR DESCRIPTION


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **New Features**
  - Introduced a new SPI basic example that demonstrates SPI bus initialization and a single SPI transaction on the ESP32-S3 platform.
  - Added build and configuration files to support compiling and running the new SPI example.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->